### PR TITLE
Pin tree-sitter version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "lz4>=3.1.0",
         "networkx>=2.5.1",
         "datasketch>=1.5.3",
-        "tree-sitter>=0.20.1",
+        "tree-sitter>=0.20.1,<0.22",
         "ray>=1.0.0",
         "psutil>=5.6.3",
         "autopep8>=1.4.4",

--- a/source_parser/_version.py
+++ b/source_parser/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"


### PR DESCRIPTION
This change is to avoid breaking change introduced by tree-sitter 0.22.0. According to [their release note](https://github.com/tree-sitter/py-tree-sitter/releases/tag/v0.22.0), `Language.build_library(...)` and `Language(path, name)` has been removed.